### PR TITLE
Feat/WPB-17550 implement mentions in messages

### DIFF
--- a/src/main/kotlin/com/wire/apps/polls/dto/app/Factories.kt
+++ b/src/main/kotlin/com/wire/apps/polls/dto/app/Factories.kt
@@ -14,13 +14,21 @@ import java.util.UUID
 fun newPoll(
     conversationId: QualifiedId,
     body: String,
-    buttons: List<Option>
-): WireMessage.Composite =
-    WireMessage.Composite.create(
+    buttons: List<Option>,
+    mentions: List<Mention>
+): WireMessage.Composite {
+    val text = WireMessage.Text(
+        id = UUID.randomUUID(),
         conversationId = conversationId,
         text = body,
-        buttonList = buttons.map { it.toWireButton() }
+        mentions = mentions.map { it.toWireMention() }
     )
+    return WireMessage.Composite(
+        id = UUID.randomUUID(),
+        conversationId = conversationId,
+        items = listOf(text) + buttons.map { it.toWireButton() }
+    )
+}
 
 /**
  * Creates message for vote confirmation.

--- a/src/main/kotlin/com/wire/apps/polls/services/PollService.kt
+++ b/src/main/kotlin/com/wire/apps/polls/services/PollService.kt
@@ -44,7 +44,8 @@ class PollService(
         val message = newPoll(
             conversationId = conversationId,
             body = poll.question.body,
-            buttons = poll.options
+            buttons = poll.options,
+            mentions = poll.question.mentions
         )
 
         val pollId = repository.savePoll(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When user would issue a poll with mentions the Poll App would return plain text.

### Causes

The `create` function provided in the SDK allows only string to be passed as a parameter.

### Solutions

Used default constructor for Composite message type.

### Notes

Currently there is a bug that SDK is unable to send mentions, but that is already fixed by @alexandreferris in #WPB-17376 and will be published with 0.0.6 release. 

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
