### PR TITLE
chore: Bump kotlin-logging from 2.0.6 to 8.0.4

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
     // logging
     implementation("net.logstash.logback", "logstash-logback-encoder", "8.1")
     implementation("ch.qos.logback", "logback-classic", "1.5.19")
-    implementation("io.github.microutils", "kotlin-logging", "2.0.6")
+    implementation("io.github.oshai", "kotlin-logging", "8.0.4")
 
     // metrics
     implementation("io.ktor", "ktor-server-metrics-micrometer", ktorVersion)

--- a/src/main/kotlin/com/wire/apps/polls/dao/PollRepository.kt
+++ b/src/main/kotlin/com/wire/apps/polls/dao/PollRepository.kt
@@ -4,7 +4,6 @@ import com.wire.apps.polls.dto.PollAction.VoteAction
 import com.wire.apps.polls.dto.PollDto
 import com.wire.apps.polls.dto.common.Mention
 import com.wire.apps.polls.dto.common.Text
-import mu.KLogging
 import org.jetbrains.exposed.sql.JoinType
 import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.batchInsert
@@ -21,8 +20,6 @@ import pw.forst.katlib.mapToSet
  */
 @Suppress("TooManyFunctions")
 class PollRepository {
-    private companion object : KLogging()
-
     /**
      * Saves given poll to database and returns its id (same as the [pollId] parameter,
      * but this design supports fluent style in the services.)

--- a/src/main/kotlin/com/wire/apps/polls/dto/PollActionMapper.kt
+++ b/src/main/kotlin/com/wire/apps/polls/dto/PollActionMapper.kt
@@ -4,7 +4,7 @@ import com.wire.apps.polls.dao.PollRepository
 import com.wire.apps.polls.utils.OPTION_BUTTON_PREFIX
 import com.wire.apps.polls.utils.RESULTS_BUTTON_ID
 import com.wire.sdk.model.WireMessage
-import mu.KLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import pw.forst.katlib.whenNull
 
 /**
@@ -15,7 +15,7 @@ import pw.forst.katlib.whenNull
 class PollActionMapper(
     private val pollRepository: PollRepository
 ) {
-    private companion object : KLogging()
+    private val logger = KotlinLogging.logger {}
 
     suspend fun fromButtonAction(buttonAction: WireMessage.ButtonAction): PollAction? =
         when {

--- a/src/main/kotlin/com/wire/apps/polls/parser/InputParser.kt
+++ b/src/main/kotlin/com/wire/apps/polls/parser/InputParser.kt
@@ -5,10 +5,12 @@ import com.wire.apps.polls.dto.PollDto
 import com.wire.apps.polls.dto.UsersInput
 import com.wire.apps.polls.dto.common.Mention
 import com.wire.apps.polls.dto.common.Text
-import mu.KLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 
 class InputParser {
-    private companion object : KLogging() {
+    private val logger = KotlinLogging.logger {}
+
+    private companion object {
         val delimiters = charArrayOf('\"', '“')
 
         val delimitersSet = delimiters.toSet()

--- a/src/main/kotlin/com/wire/apps/polls/parser/PollFactory.kt
+++ b/src/main/kotlin/com/wire/apps/polls/parser/PollFactory.kt
@@ -2,7 +2,7 @@ package com.wire.apps.polls.parser
 
 import com.wire.apps.polls.dto.PollDto
 import com.wire.apps.polls.dto.UsersInput
-import mu.KLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import pw.forst.katlib.newLine
 import pw.forst.katlib.whenNull
 
@@ -13,7 +13,7 @@ class PollFactory(
     private val inputParser: InputParser,
     private val pollValidation: PollValidation
 ) {
-    private companion object : KLogging()
+    private val logger = KotlinLogging.logger {}
 
     /**
      * Parse and create poll for the [usersInput].

--- a/src/main/kotlin/com/wire/apps/polls/parser/PollValidation.kt
+++ b/src/main/kotlin/com/wire/apps/polls/parser/PollValidation.kt
@@ -3,7 +3,6 @@ package com.wire.apps.polls.parser
 import com.wire.apps.polls.dto.Option
 import com.wire.apps.polls.dto.PollDto
 import com.wire.apps.polls.dto.common.Text
-import mu.KLogging
 
 private typealias QuestionRule = (Text) -> String?
 private typealias OptionRule = (Option) -> String?
@@ -13,8 +12,6 @@ private typealias PollRule = (PollDto) -> String?
  * Class validating the polls.
  */
 class PollValidation {
-    private companion object : KLogging()
-
     private val questionRules =
         listOf<QuestionRule> { question ->
             if (question.data.isNotBlank()) null else "The question must not be empty!"

--- a/src/main/kotlin/com/wire/apps/polls/routing/EventRoutes.kt
+++ b/src/main/kotlin/com/wire/apps/polls/routing/EventRoutes.kt
@@ -9,10 +9,10 @@ import com.wire.sdk.WireEventsHandlerSuspending
 import com.wire.sdk.model.Conversation
 import com.wire.sdk.model.ConversationMember
 import com.wire.sdk.model.WireMessage
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.server.routing.Routing
 import org.kodein.di.instance
 import org.kodein.di.ktor.closestDI
-import org.slf4j.LoggerFactory
 import kotlin.getValue
 
 /**
@@ -23,7 +23,7 @@ fun Routing.events() {
     val handler by di.instance<MessagesHandlingService>()
     val sdkConfig by di.instance<SDKConfiguration>()
     val pollActionMapper by di.instance<PollActionMapper>()
-    val logger = LoggerFactory.getLogger(this::class.java)
+    val logger = KotlinLogging.logger {}
 
     val wireAppSdk = WireAppSdk(
         applicationId = sdkConfig.appId,
@@ -35,37 +35,37 @@ fun Routing.events() {
                 conversation: Conversation,
                 members: List<ConversationMember>
             ) {
-                logger.info(
+                logger.info {
                     "Event received. Event: AppAddedToConversation, " +
                         "conversationId: ${conversation.id}"
-                )
+                }
                 handler.handleAppAddedToConversation(manager, conversation.id)
-                logger.info("App added to conversation. conversationId: ${conversation.id}")
+                logger.info { "App added to conversation. conversationId: ${conversation.id}" }
             }
 
             override suspend fun onTextMessageReceived(wireMessage: WireMessage.Text) {
-                logger.info(
+                logger.info {
                     "Event received. Event: TextMessageReceived, " +
                         "conversationId: ${wireMessage.conversationId}, " +
                         "messageId: ${wireMessage.id}, " +
                         "senderId: ${wireMessage.sender}"
-                )
+                }
                 val usersInput = fromWire(wireMessage)
                 // TODO :: It is better to validate the command here
                 //  and not go to the handler if the command is invalid
                 handler.handleUserCommand(manager, usersInput)
-                logger.info(
+                logger.info {
                     "Text message is processed. conversationId: ${wireMessage.conversationId}"
-                )
+                }
             }
 
             override suspend fun onButtonClicked(buttonAction: WireMessage.ButtonAction) {
-                logger.info(
+                logger.info {
                     "Event received. Event: ButtonClicked, " +
                         "conversationId: ${buttonAction.conversationId}, " +
                         "messageId: ${buttonAction.id}, " +
                         "senderId: ${buttonAction.sender}"
-                )
+                }
                 val pollAction = pollActionMapper.fromButtonAction(buttonAction) ?: return
 
                 handler.handlePollAction(
@@ -73,9 +73,9 @@ fun Routing.events() {
                     pollAction = pollAction,
                     conversationId = buttonAction.conversationId
                 )
-                logger.info(
+                logger.info {
                     "Button click on poll is processed. conversationId: ${buttonAction.conversationId}"
-                )
+                }
             }
         }
     )

--- a/src/main/kotlin/com/wire/apps/polls/services/MessagesHandlingService.kt
+++ b/src/main/kotlin/com/wire/apps/polls/services/MessagesHandlingService.kt
@@ -7,7 +7,7 @@ import com.wire.apps.polls.dto.UsersInput
 import com.wire.apps.polls.setup.metrics.UsageMetrics
 import com.wire.sdk.model.QualifiedId
 import com.wire.sdk.service.WireApplicationManager
-import mu.KLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 
 /**
  * Connect conversation-based events to app functionality
@@ -17,7 +17,7 @@ class MessagesHandlingService(
     private val userCommunicationService: UserCommunicationService,
     private val usageMetrics: UsageMetrics
 ) {
-    private companion object : KLogging()
+    private val logger = KotlinLogging.logger {}
 
     /**
      * Welcomes the user by listing available commands.
@@ -88,7 +88,7 @@ class MessagesHandlingService(
             trimmed == "good app" -> {
                 userCommunicationService.goodApp(manager, conversationId)
             }
-            else -> logger.debug("Ignoring the message, unrecognized command.")
+            else -> logger.debug { "Ignoring the message, unrecognized command." }
         }
     }
 }

--- a/src/main/kotlin/com/wire/apps/polls/services/PollService.kt
+++ b/src/main/kotlin/com/wire/apps/polls/services/PollService.kt
@@ -9,7 +9,7 @@ import com.wire.apps.polls.parser.PollFactory
 import com.wire.apps.polls.services.UserCommunicationService.FallbackMessageType.WRONG_COMMAND
 import com.wire.sdk.model.QualifiedId
 import com.wire.sdk.service.WireApplicationManager
-import mu.KLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import pw.forst.katlib.whenNull
 import pw.forst.katlib.whenTrue
 
@@ -22,7 +22,7 @@ class PollService(
     private val conversationService: ConversationService,
     private val userCommunicationService: UserCommunicationService
 ) {
-    private companion object : KLogging()
+    private val logger = KotlinLogging.logger {}
 
     suspend fun createPoll(
         manager: WireApplicationManager,

--- a/src/main/kotlin/com/wire/apps/polls/services/ProxySenderService.kt
+++ b/src/main/kotlin/com/wire/apps/polls/services/ProxySenderService.kt
@@ -3,13 +3,13 @@ package com.wire.apps.polls.services
 import com.wire.sdk.exception.WireException
 import com.wire.sdk.model.WireMessage
 import com.wire.sdk.service.WireApplicationManager
-import mu.KLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 
 /**
  * Service responsible for sending requests to the proxy service.
  */
 class ProxySenderService {
-    private companion object : KLogging()
+    private val logger = KotlinLogging.logger {}
 
     /**
      * Respond to the event issued by user.

--- a/src/main/kotlin/com/wire/apps/polls/services/StatsFormattingService.kt
+++ b/src/main/kotlin/com/wire/apps/polls/services/StatsFormattingService.kt
@@ -2,7 +2,7 @@ package com.wire.apps.polls.services
 
 import com.wire.apps.polls.dao.PollRepository
 import com.wire.apps.polls.dto.common.Text
-import mu.KLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import pw.forst.katlib.newLine
 import pw.forst.katlib.whenNull
 import kotlin.math.min
@@ -10,7 +10,9 @@ import kotlin.math.min
 class StatsFormattingService(
     private val repository: PollRepository
 ) {
-    private companion object : KLogging() {
+    private val logger = KotlinLogging.logger {}
+
+    private companion object {
         const val TITLE_PREFIX = "**Results** for poll *\""
 
         /**

--- a/src/main/kotlin/com/wire/apps/polls/services/UserCommunicationService.kt
+++ b/src/main/kotlin/com/wire/apps/polls/services/UserCommunicationService.kt
@@ -10,7 +10,7 @@ import com.wire.apps.polls.dto.updatePollOverviewProgressBar
 import com.wire.sdk.model.QualifiedId
 import com.wire.sdk.model.WireMessage
 import com.wire.sdk.service.WireApplicationManager
-import mu.KLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import pw.forst.katlib.whenNull
 
 /**
@@ -21,7 +21,9 @@ class UserCommunicationService(
     private val statsFormattingService: StatsFormattingService,
     private val version: String
 ) {
-    private companion object : KLogging() {
+    private val logger = KotlinLogging.logger {}
+
+    private companion object {
         private const val WELCOME_TEXT =
             "👋 Hi, I'm the Poll App. Thanks for adding me to the conversation.\n" +
                 "You can use me to create polls directly in Wire.\n" +
@@ -40,7 +42,7 @@ class UserCommunicationService(
         conversationId: QualifiedId
     ) {
         manager.send(textMessage(conversationId, WELCOME_MESSAGE))
-        logger.info("App sent a welcome message. conversationId: $conversationId")
+        logger.info { "App sent a welcome message. conversationId: $conversationId" }
     }
 
     /**

--- a/src/main/kotlin/com/wire/apps/polls/setup/DependencyInjection.kt
+++ b/src/main/kotlin/com/wire/apps/polls/setup/DependencyInjection.kt
@@ -15,7 +15,7 @@ import com.wire.apps.polls.setup.metrics.UsageMetrics
 import com.wire.apps.polls.utils.createLogger
 import io.micrometer.prometheusmetrics.PrometheusConfig
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
-import mu.KLogger
+import io.github.oshai.kotlinlogging.KLogger
 import org.kodein.di.DI
 import org.kodein.di.bind
 import org.kodein.di.instance

--- a/src/main/kotlin/com/wire/apps/polls/utils/Extensions.kt
+++ b/src/main/kotlin/com/wire/apps/polls/utils/Extensions.kt
@@ -1,8 +1,9 @@
 package com.wire.apps.polls.utils
 
-import mu.KLogging
+import io.github.oshai.kotlinlogging.slf4j.toKLogger
+import org.slf4j.LoggerFactory
 
 /**
  * Creates logger with given name.
  */
-fun createLogger(name: String) = KLogging().logger("com.wire.$name")
+fun createLogger(name: String) = LoggerFactory.getLogger("com.wire.$name").toKLogger()


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Very outdated version of logging dependency.

### Causes

The Dependabot hasn't open a PR for following reasons:
- Maven group id changed from `io.github.microutils` -> `io.github.oshai`.
- Root package change from `mu` -> `io.github.oshai.kotlinlogging`.

Source: https://github.com/oshai/kotlin-logging#version-5-vs-previous-versions

### Solutions

Manually change the Maven group id and the package name. Update syntax.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
