### PR TITLE
chore: Update wire-apps-jvm-sdk version to 0.2.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.wire", "wire-apps-jvm-sdk", "0.2.0-alpha")
+    implementation("com.wire", "wire-apps-jvm-sdk", "0.2.0")
     // stdlib
     implementation(kotlin("stdlib-jdk8"))
     // extension functions


### PR DESCRIPTION
Update wire-apps-jvm-sdk to 0.2.0 (previous was 0.2.0-alpha)